### PR TITLE
client: plugable host discovery

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft etc
+include rc.d/init.d/smokerd

--- a/etc/smokercli-example.yaml
+++ b/etc/smokercli-example.yaml
@@ -1,4 +1,4 @@
-# Example configuration file for the smoker client
+# Example configuration file for the smoker client (/etc/smokercli.yaml)
 # plugin paths: Python modules containing the host discovery plugins. It has to
 #               be valid python module path.
 

--- a/etc/smokercli.yaml
+++ b/etc/smokercli.yaml
@@ -1,0 +1,6 @@
+# Example configuration file for the smoker client
+# plugin paths: Python modules containing the host discovery plugins. It has to
+#               be valid python module path.
+
+plugin_paths:
+    - smoker.client.plugins

--- a/rc.d/init.d/smokerd
+++ b/rc.d/init.d/smokerd
@@ -32,30 +32,6 @@ exit_error() {
 	exit 1
 }
 
-confgen() {
-	if [ "$GENCONFIG" -ne 1 ]; then
-		return 0
-	fi
-
-	cat $CONFDIR/common.yaml > $CONFIG || exit_error
-
-	dirs=('template' 'action' 'plugin')
-	for dir in ${dirs[*]}; do
-		echo -e "\n${dir}s:" >> $CONFIG
-
-		# Skip if directory doesn't contain YAML files
-		if [ "`ls ${CONFDIR}/${dir}.d/*.yaml 2>/dev/null|wc -l`" -eq 0 ]; then
-			continue
-		fi
-
-		for plugin in ${CONFDIR}/${dir}.d/*.yaml; do
-			name=`basename $plugin .yaml`
-
-			echo "    ${name}: !include ${dir}.d/${name}.yaml" >> $CONFIG
-		done
-	done
-}
-
 start() {
 	[ -x $BINARY ] || exit 5
 
@@ -66,7 +42,6 @@ start() {
 	[ -f "$PIDFILE" ] && exit_error "PID file $PIDFILE already exists!"
 	[ -f "$LOCKFILE" ] && exit_error "Subsys $LOCKFILE is locked!"
 
-	confgen
 	$BINARY $SMOKERD_OPTIONS
 	RETVAL=$?
 	if [ $RETVAL -eq 0 ]; then

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ import os
 import sys
 from setuptools import setup
 
+CONFIGDIR = '/etc/smokerd'
+INITDIR = '/etc/rc.d/init.d'
+
 # Parameters for build
 params = {
     # This package is named gdc-smoker on Pypi, use it on register or upload actions
@@ -78,6 +81,10 @@ Common use-cases in short:
     'platforms' : ['POSIX'],
     'provides' : ['smoker'],
     'install_requires' : ['PyYAML', 'argparse', 'simplejson', 'psutil', 'setproctitle', 'Flask-RESTful'],
+    'data_files': [
+        (INITDIR, ['rc.d/init.d/smokerd']),
+        (CONFIGDIR, ['etc/smokerd-example.yaml', 'etc/smokercli-example.yaml'])
+    ]
 }
 
 # Get current branch
@@ -101,13 +108,6 @@ if not revision:
 build = os.getenv('BUILD_NUMBER')
 if not build:
     build = '1'
-
-# Options for installing data_files
-# Good to set in case you don't want to make RPM,
-# but just install on your workstation by python setup.py install
-PREFIX = '/usr'
-CONFIGDIR = '/etc/smokerd'
-INITDIR = '/etc/rc.d/init.d'
 
 try:
     action = sys.argv[1]
@@ -144,6 +144,8 @@ elif action == 'bdist_rpm':
     # Set release number
     sys.argv.append('--release=1.%s.%s' % (build, revision))
     # Require same version of gdc-python-common package
-    sys.argv.append('--requires=python-argparse python-simplejson python-flask')
+    sys.argv.append(
+        '--requires=python-argparse python-simplejson python-setproctitle '
+        'python-flask-restful')
 
 setup(**params)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2007-2012, GoodData(R) Corporation. All rights reserved
 
+import os
 import sys
 from setuptools import setup
 
@@ -78,5 +79,71 @@ Common use-cases in short:
     'provides' : ['smoker'],
     'install_requires' : ['PyYAML', 'argparse', 'simplejson', 'psutil', 'setproctitle', 'Flask-RESTful'],
 }
+
+# Get current branch
+branch = os.getenv('GIT_BRANCH')
+if not branch:
+    branch = os.popen(
+        'git branch|grep -v "no branch"|grep \*|sed s,\*\ ,,g').read().strip()
+
+    if not branch:
+        branch = 'master'
+else:
+    branch = branch.replace('origin/', '')
+
+# Get git revision hash
+revision = os.popen('git rev-parse --short HEAD').read().strip()
+
+if not revision:
+    revision = '0'
+
+# Get build number
+build = os.getenv('BUILD_NUMBER')
+if not build:
+    build = '1'
+
+# Options for installing data_files
+# Good to set in case you don't want to make RPM,
+# but just install on your workstation by python setup.py install
+PREFIX = '/usr'
+CONFIGDIR = '/etc/smokerd'
+INITDIR = '/etc/rc.d/init.d'
+
+try:
+    action = sys.argv[1]
+except IndexError:
+    action = None
+
+if action == 'clean':
+    # Remove MANIFEST file
+    print "Cleaning MANIFEST.."
+    try:
+        os.unlink('MANIFEST')
+    except OSError as e:
+        if e.errno == 2:
+            pass
+        else:
+            raise
+
+    # Remove dist and build directories
+    for dir in ['dist', 'build']:
+        print "Cleaning %s.." % dir
+        for root, dirs, files in os.walk(dir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        try:
+            os.rmdir(dir)
+        except OSError as e:
+            if e.errno == 2:
+                pass
+            else:
+                raise
+elif action == 'bdist_rpm':
+    # Set release number
+    sys.argv.append('--release=1.%s.%s' % (build, revision))
+    # Require same version of gdc-python-common package
+    sys.argv.append('--requires=python-argparse python-simplejson python-flask')
 
 setup(**params)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ params = {
         'smoker.server.plugins',
         'smoker.client',
         'smoker.client.out_junit',
+        'smoker.client.plugins',
         'smoker.logger',
         'smoker.util'
         ],

--- a/smoker/client/plugins/__init__.py
+++ b/smoker/client/plugins/__init__.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2007-2015, GoodData(R) Corporation. All rights reserved
+#
+# Example plugin:
+#
+# from smoker.client.plugins import SpecificArgument, HostDiscoveryPluginBase
+#
+#
+# class HostDiscoveryPlugin(HostDiscoveryPluginBase):
+#     """
+#     This is an example without any real world usability
+#     """
+#     arguments = [
+#         SpecificArgument(
+#             '-x',
+#             '--example',
+#             **{'dest': 'example',
+#                'help': 'Example parameter for host discovery'}
+#         ),
+#         SpecificArgument(
+#             '-y',
+#             '--example_prefix',
+#             **{'dest': 'prefix',
+#                'help': 'Another example for host discovery'}
+#         )
+#     ]
+#
+#     def get_hosts(self, args):
+#         if not args.example:
+#             return []
+#         if not args.prefix:
+#             return [args.example]
+#         return ['%s-%s' % (args.prefix, args.example)]
+
+
+class SpecificArgument(object):
+    """
+    Argparse argument to be added to the smoker CLI specific to this plugin
+    """
+    def __init__(self, short, long, **kwargs):
+        if short and long:
+            self.args = [short, long]
+        elif short:
+            self.args = [short]
+        else:
+            self.args = [long]
+        self.kwargs = kwargs
+
+
+class HostDiscoveryPluginBase(object):
+    """
+    Host discovery plugin interface
+    Inherit from this class when creating a host discovery plugin
+    """
+    # List of Specific Argument instances to be added
+    # to argparse.ArgumentParser
+    arguments = []
+
+    def get_hosts(self, args):
+        """
+        Override this method in your plugin
+
+        :return: discovered hosts
+        """
+        return []

--- a/smoker/server/daemon.py
+++ b/smoker/server/daemon.py
@@ -43,6 +43,8 @@ class Smokerd(object):
             lg.info("Config argument not submitted, default config file will be used!")
             self.conf['config'] = '/etc/smokerd/smokerd.yaml'
 
+        self.conf_dirs = [os.path.dirname(self.conf['config'])]
+
         self._load_config()
 
     def _yaml_include(self, loader, node):
@@ -50,7 +52,14 @@ class Smokerd(object):
         Include another yaml file from main file
         This is usually done by registering !include tag
         """
-        filepath = "%s/%s" % (os.path.dirname(self.conf['config']), node.value)
+        filepath = node.value
+        if not os.path.exists(filepath):
+            for dir in self.conf_dirs:
+                filepath = os.path.join(dir, node.value)
+                if os.path.exists(filepath):
+                    break
+
+        self.conf_dirs.append(os.path.dirname(filepath))
         try:
             with open(filepath, 'r') as inputfile:
                 return yaml.load(inputfile)

--- a/smoker/server/daemon.py
+++ b/smoker/server/daemon.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2007-2012, GoodData(R) Corporation. All rights reserved
 
+import glob
 import logging
 import os
 import signal
@@ -67,21 +68,43 @@ class Smokerd(object):
             lg.error("Can't include config file %s: %s" % (filepath, e))
             raise
 
+    def _yaml_include_dir(self, loader, node):
+        """
+        Include another yaml file from main file
+        This is usually done by registering !include tag
+        """
+        if not os.path.exists(node.value):
+            return
+
+        yamls = glob.glob(os.path.join(node.value, '*.yaml'))
+        if not yamls:
+            return
+
+        content = '\n'
+
+        for file in yamls:
+            plugin, _ = os.path.splitext(os.path.basename(file))
+            content += '    %s: !include %s\n' % (plugin, file)
+
+        return yaml.load(content)
+
     def _load_config(self):
         """
         Load specified config file
         """
         try:
-            fp = open(self.conf['config'], 'r')
+            with open(self.conf['config'], 'r') as fp:
+                config = fp.read()
         except IOError as e:
             lg.error("Can't read config file %s: %s" % (self.conf['config'], e))
             raise
 
-        # Register include constructor
+        # Register include constructors
+        yaml.add_constructor('!include_dir', self._yaml_include_dir)
         yaml.add_constructor('!include', self._yaml_include)
 
         try:
-            conf = yaml.load(fp)
+            conf = yaml.load(config)
         except Exception as e:
             lg.error("Can't parse config file %s: %s" % (self.conf['config'], e))
             raise


### PR DESCRIPTION
Add possibility of creating custom plugins for host discovery in the
client. This can be used for getting hostnames of machines deployed in
cloud based on machine type, cluster and so on.