### PR TITLE
Plugin watchdog and module execution timeout

### DIFF
--- a/rc.d/init.d/smokerd-rhel
+++ b/rc.d/init.d/smokerd-rhel
@@ -73,7 +73,7 @@ start() {
 		touch $LOCKFILE
 		# Wait a second before it's loaded and check if it's still running
 		sleep 1
-		if [ "`pgrep -f $BINARY`" ]; then
+		if [ "`pgrep -f $PROG`" ]; then
 			success
 			echo
 			return 0


### PR DESCRIPTION
If a plugin or the API server gets killed, the watchdog will restart it.
There was no timeout on python module plugins, this commit introduces
timeout configurable the same way command timeout is.