### PR TITLE
Stop timeout when plugin fails

### DIFF
--- a/smoker/client/__init__.py
+++ b/smoker/client/__init__.py
@@ -388,7 +388,11 @@ class Host(object):
 
             if not res:
                 if retries == 0:
-                    lg.error("Polling on %s failed after 3 retries" % uri)
+                    lg.error(
+                        "Polling on %s failed after 3 retries. This may "
+                        "happen when a plugin died while waiting for the "
+                        "result. Please retry and check log on the hosts if "
+                        "it happens again." % uri)
                     return False
                 else:
                     retries -= 1

--- a/smoker/server/plugins/__init__.py
+++ b/smoker/server/plugins/__init__.py
@@ -557,6 +557,7 @@ class Plugin(multiprocessing.Process):
         except Exception as e:
             lg.error("Plugin %s: module execution failed: %s" % (self.name, e))
             lg.exception(e)
+            signal.alarm(0)
             raise
 
         signal.alarm(0)


### PR DESCRIPTION
The plugin module watchdog timeout has to be stopped when module run
ends with an exception. When it's not, the module together with the rest
API server would be restarted after the timeout exceeds.