### PR TITLE
FEATURE: Maintenance lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ plugins:
 		Parser: smoker.server.plugins.varnishparser
 		# Don't run automatically
 		Interval: 0
+		# Report as warn when a file present
+		MaintenanceLock = /var/lock/maintenance.lock
 		# Just for categorization and filtering
 		Category: infrastructure
 		Component: varnish

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ else:
 # Parameters for build
 params = {
     'name': name,
-    'version': '2.0.9',
+    'version': '2.0.10',
     'packages': [
         'smoker',
         'smoker.server',

--- a/smoker.spec
+++ b/smoker.spec
@@ -1,7 +1,7 @@
 %global with_check 0
 
 Name:		smoker
-Version:	2.0.9
+Version:	2.0.10
 Release:	1%{?dist}
 Epoch:		1
 Summary:	Smoke Testing Framework

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -3,9 +3,11 @@
 # Copyright (C) 2007-2015, GoodData(R) Corporation. All rights reserved
 
 from multiprocessing import Queue
-from smoker.server.plugins import PluginManager, Plugin, PluginWorker
-import unittest
+from tempfile import mkstemp
 import time
+import unittest
+
+from smoker.server.plugins import PluginManager, Plugin, PluginWorker
 
 
 class TestPluginManager(unittest.TestCase):
@@ -57,6 +59,31 @@ class TestPlugin(unittest.TestCase):
             'Interval': 5,
             'Command': 'uptime',
             'Timeout': 5
+        }
+
+        foo = Plugin('unittest', options)
+        foo.forced = True
+        foo.run()
+        time.sleep(0.5)
+        foo.collect_new_result()
+
+
+class TestPluginMaintenance(unittest.TestCase):
+    """
+    Unit tests for the Plugin class
+    """
+
+    def setUp(self):
+        self.lockfile = mkstemp()
+
+    def test_plugin_uptime(self):
+        options = {
+            'Category': 'system',
+            'Enabled': True,
+            'Interval': 5,
+            'Command': 'uptime',
+            'Timeout': 5,
+            'MaintenanceLock': self.lockfile
         }
 
         foo = Plugin('unittest', options)


### PR DESCRIPTION
Allow skipping of a plugin run (report as OK) based on a lockfile.