### PR TITLE
BUGFIX: check plugin still alive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ else:
 # Parameters for build
 params = {
     'name': name,
-    'version': '2.1.3',
+    'version': '2.1.4',
     'packages': [
         'smoker',
         'smoker.server',

--- a/smoker.spec
+++ b/smoker.spec
@@ -1,7 +1,7 @@
 %global with_check 0
 
 Name:		smoker
-Version:	2.1.3
+Version:	2.1.4
 Release:	1%{?dist}
 Epoch:		1
 Summary:	Smoke Testing Framework

--- a/smoker/server/plugins/__init__.py
+++ b/smoker/server/plugins/__init__.py
@@ -376,7 +376,10 @@ class Plugin(object):
         Check if plugin should be run and execute it
         """
         if self.current_run:  # already running
-            return
+            if self.current_run.is_alive():
+                return
+            self.current_run.join()
+
         # Plugin run when forced
         if self.forced:
             self.current_run = PluginWorker(self.name, self.queue, self.params,


### PR DESCRIPTION
When starting a new run of a plugin and there's still previous
instance stored, check whether it's still alive. It could have
been killed by OOM killer.