### PR TITLE
Collect new results even if plugin still runs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ else:
 # Parameters for build
 params = {
     'name': name,
-    'version': '2.1.7',
+    'version': '2.1.8',
     'packages': [
         'smoker',
         'smoker.server',

--- a/smoker.spec
+++ b/smoker.spec
@@ -1,7 +1,7 @@
 %global with_check 0
 
 Name:		smoker
-Version:	2.1.7
+Version:	2.1.8
 Release:	1%{?dist}
 Epoch:		1
 Summary:	Smoke Testing Framework


### PR DESCRIPTION
Python module plugin can send results to queue while still running.
Collect them even if the plugin is still alive.