### PR TITLE
Kill all running plugins on restapi server restart

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ else:
 # Parameters for build
 params = {
     'name': name,
-    'version': '2.1.8',
+    'version': '2.1.9',
     'packages': [
         'smoker',
         'smoker.server',

--- a/smoker.spec
+++ b/smoker.spec
@@ -1,7 +1,7 @@
 %global with_check 0
 
 Name:		smoker
-Version:	2.1.8
+Version:	2.1.9
 Release:	1%{?dist}
 Epoch:		1
 Summary:	Smoke Testing Framework

--- a/smoker/server/daemon.py
+++ b/smoker/server/daemon.py
@@ -5,6 +5,7 @@
 import glob
 import logging
 import os
+import psutil
 import signal
 import sys
 import time
@@ -213,6 +214,14 @@ class Smokerd(object):
     def _restart_api_server(self):
         self.server.terminate()
         self.server.join()
+
+        # kill all the running plugins - forked from restapi server holds
+        # the smokerd port - new server cannot bind
+        for proc in psutil.process_iter():
+            if proc.name.startswith('smokerd plugin'):
+                lg.info("Killing running plugin %s", proc.name)
+                proc.kill()
+
         self.server = RestServer(
             self.conf['bind_host'], self.conf['bind_port'], self)
         self.server.start()


### PR DESCRIPTION
The plugin workers are children of the dead server and have the
8086 port open. We have to kill them all in order to release the
the port for the new restapi server.