### PR TITLE
TRIVIAL: Make requirements list compatible with RPM Python generator …

### DIFF
--- a/py3_requirements.txt
+++ b/py3_requirements.txt
@@ -1,4 +1,4 @@
-Flask-RESTful~=0.3
+Flask-RESTful>=0.3,<1
 future
 psutil
 PyYAML

--- a/smoker.spec
+++ b/smoker.spec
@@ -2,7 +2,7 @@
 
 Name:		smoker
 Version:	2.2.3
-Release:	6%{?dist}
+Release:	7%{?dist}
 Epoch:		1
 Summary:	Smoke Testing Framework
 


### PR DESCRIPTION
…from CentOS 8.3

Signed-off-by: Igor Raits <igor.raits@gmail.com>