### PR TITLE
fix: add custom YAML tag handlers for SafeLoader

### DIFF
--- a/smoker/server/daemon.py
+++ b/smoker/server/daemon.py
@@ -103,8 +103,8 @@ class Smokerd(object):
             raise
 
         # Register include constructors
-        yaml.add_constructor('!include_dir', self._yaml_include_dir)
-        yaml.add_constructor('!include', self._yaml_include)
+        yaml.SafeLoader.add_constructor('!include_dir', self._yaml_include_dir)
+        yaml.SafeLoader.add_constructor('!include', self._yaml_include)
 
         try:
             conf = yaml.safe_load(config)

--- a/smoker/server/plugins/__init__.py
+++ b/smoker/server/plugins/__init__.py
@@ -65,7 +65,7 @@ class PluginManager(object):
 
         # We don't want to have process ID 0 (first index)
         # so fill it by dummy process
-        self.processes = [{"plugins": []}]
+        self.processes = [None]
 
         self.stopping = False
 


### PR DESCRIPTION
The recent switch from UnsafeLoader to SafeLoader requires adding
constructors to a proper loader class.

Also adjust unused dummy process entry with value expected by tests.

risk: low
