### PR TITLE
fix: remove dependency on python3-future module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements.txt") as f:
 # Parameters for build
 params = {
     "name": name,
-    "version": "2.3.1",
+    "version": "2.3.2",
     "packages": [
         "smoker",
         "smoker.server",

--- a/smoker.spec
+++ b/smoker.spec
@@ -1,7 +1,7 @@
 %bcond_with check
 
 Name:		smoker
-Version:	2.3.1
+Version:	2.3.2
 Release:	0%{?dist}
 Epoch:		1
 Summary:	Smoke Testing Framework

--- a/smoker/server/plugins/__init__.py
+++ b/smoker/server/plugins/__init__.py
@@ -15,7 +15,6 @@ import time
 from builtins import object, str
 
 import setproctitle
-from past.builtins import basestring
 
 import smoker.util.command
 from smoker.server.exceptions import (
@@ -348,7 +347,7 @@ class Plugin(object):
         :param params: keyword arguments
         :type params: dict
         """
-        assert isinstance(name, basestring)
+        assert isinstance(name, str)
         assert isinstance(params, dict)
         self.name = name
         self.params = dict(self.params_default, **params)
@@ -777,7 +776,7 @@ class PluginWorker(multiprocessing.Process):
                         escaped[key] = re.escape(value)
                     except Exception:
                         escaped[key] = value
-        elif isinstance(tbe, basestring):
+        elif isinstance(tbe, (str, bytes)):
             try:
                 escaped = re.escape(tbe)
             except Exception:
@@ -992,7 +991,7 @@ class Result(object):
                             % (t, type(msg[t]).__name__)
                         )
                     for out in msg[t]:
-                        if not isinstance(out, basestring):
+                        if not isinstance(out, (str, bytes)):
                             raise ValidationError(
                                 "Result message type %s has to be a string, not %s"
                                 % (t, type(out).__name__)


### PR DESCRIPTION
Use native types instead of deprecated python2-specific
`basestring` type. There should be `str` everywhere, but due to
a loose type handling in existing code I follow the original
`(str, bytes)` just to be sure it will not break somewhere.

risk: low
